### PR TITLE
Add AI content suggestion for notes

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -123,14 +123,22 @@ async def generate_diagram(req: RequestBody):
 async def note_hint(data: dict = Body(...)):
     existing_notes = data.get("existingNotes", "")
     title = data.get("title", "New Note")
+    content = data.get("content", "")
 
     full_prompt = (
         f"You are helping a user design a software architecture using sticky notes.\n"
         f"The user has already written the following notes:\n\n"
         f"{existing_notes}\n\n"
-        f"Now they added a new note titled: {title}\n"
-        f"Please suggest content for this note that complements the existing ones."
+        f"Now they added a new note titled: {title}.\n"
     )
+
+    if content:
+        full_prompt += (
+            f"The note already contains the following text:\n{content}\n"
+            f"Please provide a suggestion to continue or complete this note so it complements the others."
+        )
+    else:
+        full_prompt += "Please suggest content for this note that complements the existing ones."
 
     response = await client.chat.completions.create(
         model="deepseek-chat",
@@ -142,5 +150,4 @@ async def note_hint(data: dict = Body(...)):
 
     return {"suggestion": response.choices[0].message.content.strip()}
 
-if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+if __name__ == "__main__":    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend_Gemini.py
+++ b/backend_Gemini.py
@@ -91,14 +91,22 @@ async def generate_diagram(req: RequestBody):
 async def note_hint(data: dict = Body(...)):
     existing_notes = data.get("existingNotes", "")
     title = data.get("title", "New Note")
+    content = data.get("content", "")
 
     full_prompt = (
         f"You are helping a user design a software architecture using sticky notes.\n"
         f"The user has already written the following notes:\n\n"
         f"{existing_notes}\n\n"
-        f"Now they added a new note titled: {title}\n"
-        f"Please suggest content for this note that complements the existing ones."
+        f"Now they added a new note titled: {title}.\n"
     )
+
+    if content:
+        full_prompt += (
+            f"The note already contains the following text:\n{content}\n"
+            f"Please provide a suggestion to continue or complete this note so it complements the others."
+        )
+    else:
+        full_prompt += "Please suggest content for this note that complements the existing ones."
 
     response = gemini_model.generate_content(full_prompt)
     return {"suggestion": response.text.strip()}

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
                             <div class="note-title" tabindex="0">Game Concept</div>
                         </div>
                         <div class="note-actions">
+                            <div class="note-action suggest-action" title="AI Suggest"><i class="fas fa-magic"></i></div>
                             <div class="note-action"><i class="fas fa-times"></i></div>
                         </div>
                     </div>
@@ -138,6 +139,7 @@
                             <div class="note-title" tabindex="0">Technical Requirements</div>
                         </div>
                         <div class="note-actions">
+                            <div class="note-action suggest-action" title="AI Suggest"><i class="fas fa-magic"></i></div>
                             <div class="note-action"><i class="fas fa-times"></i></div>
                         </div>
                     </div>
@@ -159,6 +161,7 @@
                             <div class="note-title" tabindex="0">Target Audience</div>
                         </div>
                         <div class="note-actions">
+                            <div class="note-action suggest-action" title="AI Suggest"><i class="fas fa-magic"></i></div>
                             <div class="note-action"><i class="fas fa-times"></i></div>
                         </div>
                     </div>

--- a/js/notes.js
+++ b/js/notes.js
@@ -104,7 +104,12 @@
                 const original = contentDiv.innerText;
                 contentDiv.innerText = '(Generating suggestion from AI...)';
 
-                fetch('/api/note_hint', {
+                const overlay = document.createElement('div');
+                overlay.className = 'loading-overlay';
+                overlay.innerHTML = '<div class="spinner"></div>';
+                whiteboard.appendChild(overlay);
+
+                fetch('http://127.0.0.1:8000/api/note_hint', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ existingNotes, title: titleText, content: existingContent })
@@ -120,6 +125,11 @@
                     .catch(err => {
                         console.error('AI suggestion failed', err);
                         contentDiv.innerText = original;
+                    })
+                    .finally(() => {
+                        if (whiteboard.contains(overlay)) {
+                            whiteboard.removeChild(overlay);
+                        }
                     });
             });
         }
@@ -179,7 +189,12 @@
                 .filter(text => text.length > 0)
                 .join("\n\n");
 
-            fetch("/api/note_hint", {
+            const overlay = document.createElement('div');
+            overlay.className = 'loading-overlay';
+            overlay.innerHTML = '<div class="spinner"></div>';
+            whiteboard.appendChild(overlay);
+
+            fetch("http://127.0.0.1:8000/api/note_hint", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ existingNotes, title: title.textContent.trim(), content: "" })
@@ -187,6 +202,11 @@
                 .then(res => res.json())
                 .then(data => {
                     content.innerText = data.suggestion;
+                })
+                .finally(() => {
+                    if (whiteboard.contains(overlay)) {
+                        whiteboard.removeChild(overlay);
+                    }
                 });
         }
     }


### PR DESCRIPTION
## Summary
- enhance `/api/note_hint` endpoint to accept existing content
- add AI suggestion button in note UI
- support generating suggestions based on title and partial text

## Testing
- `python -m py_compile backend.py backend_Gemini.py`
- `node --check js/notes.js`

------
https://chatgpt.com/codex/tasks/task_e_686dabec15c08322be676da5b01a5bd5