### PR TITLE
Add MCQ question generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,25 @@ We are building a multiplayer online Tetris game that allows players to compete 
           <button class="add-note-btn" id="addNoteBtn">
             <i class="fas fa-plus"></i> Add Sticky Note
           </button>
+          <!-- MCQ Question Generator -->
+          <div class="control-group">
+            <h2 class="control-title">
+              <i class="fas fa-question-circle"></i> Assessment
+            </h2>
+            <select id="questionCategory">
+              <option>Project Basics</option>
+              <option>User Behavior &amp; Connectivity</option>
+              <option>Data &amp; Storage</option>
+              <option>Performance &amp; Scalability</option>
+              <option>Security &amp; Access Control</option>
+              <option>Deployment &amp; DevOps</option>
+              <option>Observability &amp; Reliability</option>
+              <option>Cost &amp; Business Model</option>
+            </select>
+            <button id="generateMCQBtn">
+              <i class="fas fa-question"></i> Generate MCQ
+            </button>
+          </div>
         </div>
 
         <!-- Collaboration Panel -->
@@ -386,6 +405,7 @@ We are building a multiplayer online Tetris game that allows players to compete 
     <script src="js/favorites.js"></script>
     <script src="js/architecture.js"></script>
     <script src="js/diagram.js"></script>
+    <script src="js/questions.js"></script>
     <script src="js/collaboration.js"></script>
     <script src="js/main.js"></script>
   </body>

--- a/js/global_variables.js
+++ b/js/global_variables.js
@@ -1,4 +1,6 @@
-// DOM Ԫ��
+window.generateMcqBtn = document.getElementById("generateMCQBtn");
+window.questionCategory = document.getElementById("questionCategory");
+// DOM ÔªËØ
 window.whiteboard = document.getElementById('whiteboard');
 window.addNoteBtn = document.getElementById('addNoteBtn');
 window.generateBtn = document.getElementById('generateBtn');
@@ -12,7 +14,7 @@ window.docCount = docBin.querySelector('.doc-count');
 window.docList = docBin.querySelector('.doc-list');
 window.bins = document.getElementById('bins');
 
-// ״̬����
+// ×´Ì¬±äÁ¿
 window.noteCount = 3;
 window.deletedNotes = 0;
 window.savedNotesArr = [];

--- a/js/main.js
+++ b/js/main.js
@@ -1,20 +1,22 @@
 document.addEventListener('DOMContentLoaded', () => {
-    // ³õÊ¼»¯±ãÇ©Âß¼­
+    // åˆå§‹åŒ–MCQ
+    if (window.initQuestions) window.initQuestions();
+    // åˆå§‹åŒ–ä¾¿ç­¾é€»è¾‘
     if (window.initNotes) window.initNotes();
 
-    // ³õÊ¼»¯À¬»øÍ°
+    // åˆå§‹åŒ–åƒåœ¾æ¡¶
     if (window.initTrashBin) window.initTrashBin();
 
-    // ³õÊ¼»¯ÊÕ²Ø¼Ğ
+    // åˆå§‹åŒ–æ”¶è—å¤¹
     if (window.initFavorites) window.initFavorites();
 
-    // ³õÊ¼»¯¼Ü¹¹Éú³É
+    // åˆå§‹åŒ–æ¶æ„ç”Ÿæˆ
     if (window.initArchitecture) window.initArchitecture();
 
-    // ³õÊ¼»¯Á÷³ÌÍ¼Éú³É
+    // åˆå§‹åŒ–æµç¨‹å›¾ç”Ÿæˆ
     if (window.initDiagram) window.initDiagram();
 
-    // ³õÊ¼»¯ Mermaid
+    // åˆå§‹åŒ– Mermaid
     if (window.mermaid) {
         window.mermaid.initialize({
             startOnLoad: false,

--- a/js/questions.js
+++ b/js/questions.js
@@ -1,0 +1,66 @@
+function initQuestions() {
+    const mcqBtn = document.getElementById('generateMCQBtn');
+    if (!mcqBtn) return;
+    mcqBtn.addEventListener('click', async function () {
+        const category = document.getElementById('questionCategory').value;
+        const overlay = document.createElement('div');
+        overlay.className = 'loading-overlay';
+        overlay.innerHTML = '<div class="spinner"></div>';
+        whiteboard.appendChild(overlay);
+
+        const appType = document.getElementById('appType').value;
+        const userCount = document.getElementById('userCount').value;
+        const projectDesc = document.getElementById('projectDesc').value;
+        const features = [];
+        for (let i = 1; i <= 8; i++) {
+            if (document.getElementById('feature' + i).checked) {
+                features.push(document.querySelector('label[for="feature' + i + '"]').textContent);
+            }
+        }
+        const notes = Array.from(document.querySelectorAll('.note'))
+            .map(n => n.innerText.trim())
+            .filter(t => t !== '');
+
+        try {
+            const response = await fetch('http://127.0.0.1:8000/api/generate_mcq', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    category,
+                    prompt: projectDesc,
+                    appType,
+                    features,
+                    userCount,
+                    notes
+                })
+            });
+            const data = await response.json();
+            if (whiteboard.contains(overlay)) whiteboard.removeChild(overlay);
+            const note = document.createElement('div');
+            note.className = 'note result-note';
+            note.style.top = '200px';
+            note.style.left = '200px';
+            note.innerHTML = `
+                <div class="note-header">
+                    <div>
+                        <div class="title-edit-tooltip">Double-click to edit title</div>
+                        <div class="note-title" tabindex="0">${category}</div>
+                    </div>
+                    <div class="note-actions">
+                        <div class="note-action"><i class="fas fa-times"></i></div>
+                    </div>
+                </div>
+                <div class="note-content">${data.mcq || ''}</div>
+            `;
+            whiteboard.appendChild(note);
+            addNoteEvents(note);
+            note.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } catch (err) {
+            if (whiteboard.contains(overlay)) whiteboard.removeChild(overlay);
+            alert('MCQ generation failed.');
+            console.error('generateMCQ failed:', err);
+        }
+    });
+}
+
+window.initQuestions = initQuestions;


### PR DESCRIPTION
## Summary
- add UI controls and JS module to create MCQ questions
- support MCQ generation in backend for OpenAI and Gemini
- expose new script on frontend

## Testing
- `python -m py_compile backend.py backend_Gemini.py`

------
https://chatgpt.com/codex/tasks/task_e_68801455f468832281b5b837ed3a52c2