### PR TITLE
Add MCQ generation improvements

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -133,8 +133,9 @@ async def generate_mcq(req: MCQRequest):
         f"问题分类: {req.category}"
     )
     user_msg = (
-        "基于以上信息，生成一个四选一的选择题。"
-        "请提供简短的问题以及A、B、C、D四个答案，不要附加任何额外内容。"
+        "Using the above information, identify a project aspect that is missing "
+        "or unclear. Ask one short multiple-choice question in English to clar"
+        "ify it and provide options A, B, C and D only without any extra text."
     )
     response = await client.chat.completions.create(
         model="deepseek-chat",

--- a/backend_Gemini.py
+++ b/backend_Gemini.py
@@ -112,7 +112,10 @@ async def generate_mcq(req: MCQRequest):
         f"项目描述: {req.prompt}\n"
         f"问题分类: {req.category}"
     )
-    user_msg = "基于以上信息，生成一个四选一的选择题。请只给出问题和A、B、C、D四个答案。"
+    user_msg = (
+        "Using the above information, identify a project aspect that is missing or unclear. "
+        "Ask one short multiple-choice question in English to clarify it and provide options A, B, C and D only."
+    )
     response = gemini_model.generate_content(base_prompt + "\n" + user_msg)
     return {"mcq": response.text.strip()}
 

--- a/index.html
+++ b/index.html
@@ -106,22 +106,10 @@ We are building a multiplayer online Tetris game that allows players to compete 
             >
           </div>
 
-          <!-- 生成架构按钮 -->
-          <button id="generateBtn">
-            <i class="fas fa-brain"></i> Generate Architecture
-          </button>
-          <!--生成流程图按钮-->
-          <button id="generateDiagramBtn">
-            <i class="fas fa-project-diagram"></i> Generate Diagram
-          </button>
-          <!-- 添加便签按钮 -->
-          <button class="add-note-btn" id="addNoteBtn">
-            <i class="fas fa-plus"></i> Add Sticky Note
-          </button>
           <!-- MCQ Question Generator -->
           <div class="control-group">
             <h2 class="control-title">
-              <i class="fas fa-question-circle"></i> Assessment
+              <i class="fas fa-question-circle"></i> Generate MCQ
             </h2>
             <select id="questionCategory">
               <option>Project Basics</option>
@@ -137,6 +125,19 @@ We are building a multiplayer online Tetris game that allows players to compete 
               <i class="fas fa-question"></i> Generate MCQ
             </button>
           </div>
+
+          <!-- 生成架构按钮 -->
+          <button id="generateBtn">
+            <i class="fas fa-brain"></i> Generate Architecture
+          </button>
+          <!--生成流程图按钮-->
+          <button id="generateDiagramBtn">
+            <i class="fas fa-project-diagram"></i> Generate Diagram
+          </button>
+          <!-- 添加便签按钮 -->
+          <button class="add-note-btn" id="addNoteBtn">
+            <i class="fas fa-plus"></i> Add Sticky Note
+          </button>
         </div>
 
         <!-- Collaboration Panel -->

--- a/js/questions.js
+++ b/js/questions.js
@@ -40,6 +40,7 @@ function initQuestions() {
             note.className = 'note result-note';
             note.style.top = '200px';
             note.style.left = '200px';
+            const optionName = 'mcq-' + Date.now();
             note.innerHTML = `
                 <div class="note-header">
                     <div>
@@ -50,7 +51,15 @@ function initQuestions() {
                         <div class="note-action"><i class="fas fa-times"></i></div>
                     </div>
                 </div>
-                <div class="note-content">${data.mcq || ''}</div>
+                <div class="note-content">
+                    <pre>${data.mcq || ''}</pre>
+                    <div class="mcq-options">
+                        <label><input type="radio" name="${optionName}" value="A">A</label>
+                        <label><input type="radio" name="${optionName}" value="B">B</label>
+                        <label><input type="radio" name="${optionName}" value="C">C</label>
+                        <label><input type="radio" name="${optionName}" value="D">D</label>
+                    </div>
+                </div>
             `;
             whiteboard.appendChild(note);
             addNoteEvents(note);

--- a/style.css
+++ b/style.css
@@ -788,6 +788,23 @@ button {
     padding-right: 5px;
     display: flex;
     flex-direction: column;
+    gap: 8px;
+}
+
+.note-content pre {
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.mcq-options {
+    display: flex;
+    gap: 10px;
+}
+
+.mcq-options label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
     .note-content::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- rename and move MCQ generator block under Project Description
- update backend prompts so MCQs clarify missing specs
- display MCQ question with radio buttons
- style MCQ options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68802093fa848322a15af5c07ed8af39